### PR TITLE
Prevent duplicate RSS links

### DIFF
--- a/infrastructure/postgre/init/sql_init.sql
+++ b/infrastructure/postgre/init/sql_init.sql
@@ -294,6 +294,10 @@ CREATE TABLE links (
                                  -- rather than one huge for all links of all feeds
 
 CREATE INDEX feed_link ON links ( feed_id ASC, link ASC );
+-- make sure that the same link for a single feed
+-- cannot be stored multiple times even when concurrent
+-- insertions happen at the same time
+CREATE UNIQUE INDEX feed_link_unique ON links( feed_id, link );
 CREATE INDEX feed_processed ON links (feed_id ASC, is_processed ASC );
 CREATE INDEX processed_fetched ON links (is_processed DESC, date_fetched DESC );
 
@@ -305,15 +309,18 @@ DECLARE
     inserted_link_id BIGINT := 0;
     existing_links_count SMALLINT;
 BEGIN
-    -- check that the link doesn't exist
+    -- check that the link doesn't already exist
     existing_links_count := ( SELECT Count( * ) as Total FROM links WHERE feed_id = id_feed AND links.link = link_url );
     IF ( existing_links_count = 0 ) THEN
         -- make sure that our partitions exist
         EXECUTE format( 'CREATE TABLE IF NOT EXISTS %I PARTITION OF links FOR VALUES IN( %L ) PARTITION BY RANGE ( date_fetched )', 'links_' || id_feed::TEXT, id_feed );
         EXECUTE format( 'CREATE TABLE IF NOT EXISTS %I PARTITION OF links_' || id_feed::TEXT || ' FOR VALUES FROM( %L ) TO ( %L )', 'links_' || id_feed::TEXT || '_' || TO_CHAR( CURRENT_DATE, 'mm_yyyy' ), EXTRACT( epoch FROM ( TO_CHAR( CURRENT_DATE, 'yyyy-mm' ) || '-01' )::DATE )::INT, EXTRACT( epoch FROM ( TO_CHAR( CURRENT_DATE, 'yyyy') || '-' || EXTRACT( MONTH FROM NOW() + '1 month'::INTERVAL )::INT || '-01' )::DATE )::INT );
 
-        -- insert the link
-        INSERT INTO links( feed_id, title, description, link, img, date_posted ) VALUES ( id_feed, title_text, description_text, link_url, img_url, date_posted_ts ) RETURNING id INTO inserted_link_id;
+        -- insert the link, avoiding duplicates thanks to the unique index
+        INSERT INTO links( feed_id, title, description, link, img, date_posted )
+        VALUES ( id_feed, title_text, description_text, link_url, img_url, date_posted_ts )
+        ON CONFLICT (feed_id, link) DO NOTHING
+        RETURNING id INTO inserted_link_id;
     END IF;
 
     RETURN inserted_link_id;


### PR DESCRIPTION
## Summary
- avoid concurrent duplicates by adding a unique index for feed/link pairs
- simplify `insert_new_link` to use `ON CONFLICT` with that unique index
- skip RSS fetch if another worker already handles the same feed by using a Redis lock
- restore link existence check so partitions are only created once
- document TTL of the distributed lock

## Testing
- `npx tsc -p workers/rss_fetch/app/tsconfig.json --noEmit` *(fails: Cannot find module type declarations)*
- `npm install` *(fails: download of dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6858eb2d256083329de61fe0a1cb2518